### PR TITLE
Revert "fixed virtual repeat for autocomplete"

### DIFF
--- a/addon/components/paper-virtual-repeat.js
+++ b/addon/components/paper-virtual-repeat.js
@@ -194,10 +194,6 @@ const VirtualRepeatComponent = VirtualEachComponent.extend({
 
   }).readOnly(),
 
-  visibleItemsVirtual: computed.map('_items', function(item, index) {
-    return { raw: item, virtualIndex: index };
-  }).readOnly(),
-
   visibleItems: computed('_startAt', '_visibleItemCount', '_items', function() {
 
     let items = get(this, '_items');
@@ -218,10 +214,15 @@ const VirtualRepeatComponent = VirtualEachComponent.extend({
           items[i] = getAtIndex(i);
         }
       }
-      this.notifyPropertyChange('_items');
     }
 
-    return this.get('visibleItemsVirtual').slice(startAt, endAt);
+    return items.slice(startAt, endAt).map((item, index) => (
+      {
+        raw: item,
+        actualIndex: startAt + index,
+        virtualIndex: index
+      })
+    );
   }).readOnly(),
 
   scrollToVirtualItem(newIndex, toTop=false) {


### PR DESCRIPTION
Reverts pauln/ember-paper#5

Caused an issue whereby multiple items were highlighted after scrolling the dropdown, and the wrong item was selected when clicking.